### PR TITLE
add request state details

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ L = length (9)
 M = message content (always 5, 5, 5, 5, 5)
 C = checksum
 
-   L           M           C
-   /\ /-------------------\ /---\
+   L       M           C
+   /\ /------------\ /---\
 fe 09 05 05 05 05 05 XX XX
 ```
 
@@ -270,7 +270,7 @@ fe 09 05 05 05 05 05 XX XX
 |-|-|-|
 |*Current State*|cube->app|no|
 
-Sent in response to a [*Request State*](#request-state) command.
+Sent in response to a [*Request State*](#request-state) command. The format of this packet is identical to [*Sync Confirmation*](#sync-confirmation) execpt for the opcode (0x5)
 
 ```
 L = length (38)


### PR DESCRIPTION
Hello,

As I was creating a javascript implementation of this protocol [qysc-web](https://github.com/simonkellly/qysc-web) I came across this packet while programmatically spamming the cube with other opcodes + messages. I am not sure if this packet is used by the original cube app.

I don't generally use rust/lua so I didn't include an implementation for the packets in the Wireshark dissector or example app, but I have been successfully using this in my own software.

Thank you for your great work on this project!